### PR TITLE
Compile the project with .net 4.0 instead of 4.5

### DIFF
--- a/DapperExtensions/SQLinq.Dapper.Test/SQLinq.Dapper.Test.csproj
+++ b/DapperExtensions/SQLinq.Dapper.Test/SQLinq.Dapper.Test.csproj
@@ -11,7 +11,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SQLinq.Dapper.Test</RootNamespace>
     <AssemblyName>SQLinq.Dapper.Test</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <SccProjectName>SAK</SccProjectName>

--- a/DapperExtensions/SQLinq.Dapper/SQLinq.Dapper.csproj
+++ b/DapperExtensions/SQLinq.Dapper/SQLinq.Dapper.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SQLinq.Dapper</RootNamespace>
     <AssemblyName>SQLinq.Dapper</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
@@ -47,14 +47,16 @@
     </AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Dapper, Version=1.40.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Dapper.1.42\lib\net45\Dapper.dll</HintPath>
+    <Reference Include="Dapper, Version=1.50.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Dapper.1.50.2\lib\net40\Dapper.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="DictionaryParameterObject.cs" />

--- a/DapperExtensions/SQLinq.Dapper/packages.config
+++ b/DapperExtensions/SQLinq.Dapper/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Dapper" version="1.42" targetFramework="net45" />
+  <package id="Dapper" version="1.50.2" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
Hi,

It seems to me that there is no reason to make SQLinq.Dapper dependent on .net 4.5.
I have updated it to only require .net 4.0, this will increase the availability.

Thank you for the library :),
Alin GHERMAN